### PR TITLE
Add context manager support for database connections

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,16 @@ Rolls back the current transaction and starts a new one.
 
 Closes the database connection.
 
+### `with` statement
+
+Connection objects can be used as context managers to ensure that transactions are properly committed or rolled back. When entering the context, the connection object is returned. When exiting:
+- Without exception: automatically commits the transaction
+- With exception: automatically rolls back the transaction
+
+This behavior is compatible with Python's `sqlite3` module. Context managers work correctly in both transactional and autocommit modes.
+
+When mixing manual transaction control with context managers, the context manager's commit/rollback will apply to any active transaction at the time of exit. Manual calls to `commit()` or `rollback()` within the context are allowed and will start a new transaction as usual.
+
 ### execute(sql, parameters=())
 
 Create a new cursor object and executes the SQL statement.

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -6,15 +6,18 @@ import libsql
 import pytest
 import tempfile
 
+
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_connection_timeout(provider):
     conn = connect(provider, ":memory:", timeout=1.0)
     conn.close()
 
+
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_connection_close(provider):
     conn = connect(provider, ":memory:")
     conn.close()
+
 
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_execute(provider):
@@ -34,6 +37,7 @@ def test_cursor_execute(provider):
     res = cur.execute("SELECT * FROM users")
     assert (1, "alice@example.com") == res.fetchone()
 
+
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_cursor_close(provider):
     conn = connect(provider, ":memory:")
@@ -46,6 +50,7 @@ def test_cursor_close(provider):
     cur.close()
     with pytest.raises(Exception):
         cur.execute("SELECT * FROM users")
+
 
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_executemany(provider):
@@ -198,7 +203,9 @@ def test_connection_autocommit(provider):
     res = cur.execute("SELECT * FROM users")
     assert (1, "alice@example.com") == res.fetchone()
 
-    conn = connect(provider, ":memory:", timeout=5, isolation_level="DEFERRED", autocommit=-1)
+    conn = connect(
+        provider, ":memory:", timeout=5, isolation_level="DEFERRED", autocommit=-1
+    )
     assert conn.isolation_level == "DEFERRED"
     assert conn.autocommit == -1
     cur = conn.cursor()
@@ -210,7 +217,9 @@ def test_connection_autocommit(provider):
     assert (1, "alice@example.com") == res.fetchone()
 
     # Test autocommit Enabled (True)
-    conn = connect(provider, ":memory:", timeout=5, isolation_level=None, autocommit=True)
+    conn = connect(
+        provider, ":memory:", timeout=5, isolation_level=None, autocommit=True
+    )
     assert conn.isolation_level == None
     assert conn.autocommit == True
     cur = conn.cursor()
@@ -221,7 +230,9 @@ def test_connection_autocommit(provider):
     res = cur.execute("SELECT * FROM users")
     assert (1, "bob@example.com") == res.fetchone()
 
-    conn = connect(provider, ":memory:", timeout=5, isolation_level="DEFERRED", autocommit=True)
+    conn = connect(
+        provider, ":memory:", timeout=5, isolation_level="DEFERRED", autocommit=True
+    )
     assert conn.isolation_level == "DEFERRED"
     assert conn.autocommit == True
     cur = conn.cursor()
@@ -233,7 +244,9 @@ def test_connection_autocommit(provider):
     assert (1, "bob@example.com") == res.fetchone()
 
     # Test autocommit Disabled (False)
-    conn = connect(provider, ":memory:", timeout=5, isolation_level="DEFERRED", autocommit=False)
+    conn = connect(
+        provider, ":memory:", timeout=5, isolation_level="DEFERRED", autocommit=False
+    )
     assert conn.isolation_level == "DEFERRED"
     assert conn.autocommit == False
     cur = conn.cursor()
@@ -260,6 +273,7 @@ def test_params(provider):
     res = cur.execute("SELECT * FROM users")
     assert (1, "alice@example.com") == res.fetchone()
 
+
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_none_param(provider):
     conn = connect(provider, ":memory:")
@@ -271,6 +285,7 @@ def test_none_param(provider):
     results = res.fetchall()
     assert results[0] == (1, None)
     assert results[1] == (2, "alice@example.com")
+
 
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_fetchmany(provider):
@@ -321,6 +336,194 @@ def test_int64(provider):
     assert [(1, 1099511627776)] == res.fetchall()
 
 
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_commit(provider):
+    """Test that context manager commits on clean exit"""
+    conn = connect(provider, ":memory:")
+    with conn as c:
+        c.execute("CREATE TABLE t(x)")
+        c.execute("INSERT INTO t VALUES (1)")
+    # Changes should be committed
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 1
+
+
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_rollback(provider):
+    """Test that context manager rolls back on exception"""
+    conn = connect(provider, ":memory:")
+    try:
+        with conn as c:
+            c.execute("CREATE TABLE t(x)")
+            c.execute("INSERT INTO t VALUES (1)")
+            raise ValueError("Test exception")
+    except ValueError:
+        pass
+    # Changes should be rolled back
+    cur = conn.cursor()
+    try:
+        cur.execute("SELECT COUNT(*) FROM t")
+        # If we get here, the table exists (rollback didn't work)
+        assert False, "Table should not exist after rollback"
+    except Exception:
+        # Table doesn't exist, which is what we expect after rollback
+        pass
+
+
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_autocommit(provider):
+    """Test that context manager works correctly with autocommit mode"""
+    conn = connect(provider, ":memory:", isolation_level=None)  # autocommit mode
+    with conn as c:
+        c.execute("CREATE TABLE t(x)")
+        c.execute("INSERT INTO t VALUES (1)")
+    # In autocommit mode, changes are committed immediately
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 1
+
+
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_nested(provider):
+    """Test nested context managers"""
+    conn = connect(provider, ":memory:")
+    with conn as c1:
+        c1.execute("CREATE TABLE t(x)")
+        c1.execute("INSERT INTO t VALUES (1)")
+        with conn as c2:
+            c2.execute("INSERT INTO t VALUES (2)")
+        # Inner context commits
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM t")
+        assert cur.fetchone()[0] == 2
+    # Outer context also commits
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 2
+
+
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_connection_reuse(provider):
+    """Test that connection remains usable after context manager exit"""
+    conn = connect(provider, ":memory:")
+    
+    # First use with context manager
+    with conn as c:
+        c.execute("CREATE TABLE t(x)")
+        c.execute("INSERT INTO t VALUES (1)")
+    
+    # Connection should still be valid
+    cur = conn.cursor()
+    cur.execute("INSERT INTO t VALUES (2)")
+    conn.commit()
+    
+    # Verify both inserts worked
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 2
+    
+    # Use context manager again
+    with conn as c:
+        c.execute("INSERT INTO t VALUES (3)")
+    
+    # Final verification
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 3
+    
+    conn.close()
+
+
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_nested_exception(provider):
+    """Test exception handling in nested context managers"""
+    conn = connect(provider, ":memory:")
+    
+    # Create table outside context
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    
+    # Test that nested context managers share the same transaction
+    # An exception in an inner context will roll back the entire transaction
+    try:
+        with conn as c1:
+            c1.execute("INSERT INTO t VALUES (1)")
+            try:
+                with conn as c2:
+                    c2.execute("INSERT INTO t VALUES (2)")
+                    raise ValueError("Inner exception")
+            except ValueError:
+                pass
+            # The inner rollback affects the entire transaction
+            # So value 1 is also rolled back
+            c1.execute("INSERT INTO t VALUES (3)")
+    except:
+        pass
+    
+    # Only value 3 should be committed (1 and 2 were rolled back together)
+    cur = conn.cursor()
+    cur.execute("SELECT x FROM t ORDER BY x")
+    results = cur.fetchall()
+    assert results == [(3,)]
+    
+    # Test outer exception after nested context commits
+    conn.execute("DROP TABLE t")
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    
+    try:
+        with conn as c1:
+            c1.execute("INSERT INTO t VALUES (10)")
+            with conn as c2:
+                c2.execute("INSERT INTO t VALUES (20)")
+                # Inner context will commit both values
+            # This will cause outer rollback but values are already committed
+            raise RuntimeError("Outer exception")
+    except RuntimeError:
+        pass
+    
+    # Values 10 and 20 should be committed by inner context
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 2
+
+
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_context_manager_manual_transaction_control(provider):
+    """Test mixing manual transaction control with context managers"""
+    conn = connect(provider, ":memory:")
+    
+    with conn as c:
+        c.execute("CREATE TABLE t(x)")
+        c.execute("INSERT INTO t VALUES (1)")
+        
+        # Manual commit within context
+        c.commit()
+        
+        # Start new transaction
+        c.execute("INSERT INTO t VALUES (2)")
+        # This will be committed by context manager
+    
+    # Both values should be present
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM t")
+    assert cur.fetchone()[0] == 2
+    
+    # Test manual rollback within context
+    with conn as c:
+        c.execute("INSERT INTO t VALUES (3)")
+        
+        # Manual rollback
+        c.rollback()
+        
+        # New transaction
+        c.execute("INSERT INTO t VALUES (4)")
+        # This will be committed by context manager
+    
+    # Should have values 1, 2, and 4 (not 3)
+    cur.execute("SELECT x FROM t ORDER BY x")
+    results = cur.fetchall()
+    assert results == [(1,), (2,), (4,)]
+
+
 def connect(provider, database, timeout=5, isolation_level="DEFERRED", autocommit=-1):
     if provider == "libsql-remote":
         from urllib import request
@@ -331,9 +534,7 @@ def connect(provider, database, timeout=5, isolation_level="DEFERRED", autocommi
             raise Exception("libsql-remote server is not running")
         if res.getcode() != 200:
             raise Exception("libsql-remote server is not running")
-        return libsql.connect(
-            database, sync_url="http://localhost:8080", auth_token=""
-        )
+        return libsql.connect(database, sync_url="http://localhost:8080", auth_token="")
     if provider == "libsql":
         if sys.version_info < (3, 12):
             return libsql.connect(
@@ -343,15 +544,23 @@ def connect(provider, database, timeout=5, isolation_level="DEFERRED", autocommi
             if autocommit == -1:
                 autocommit = libsql.LEGACY_TRANSACTION_CONTROL
             return libsql.connect(
-                database, timeout=timeout, isolation_level=isolation_level, autocommit=autocommit
+                database,
+                timeout=timeout,
+                isolation_level=isolation_level,
+                autocommit=autocommit,
             )
     if provider == "sqlite":
         if sys.version_info < (3, 12):
-            return sqlite3.connect(database, timeout=timeout, isolation_level=isolation_level)
+            return sqlite3.connect(
+                database, timeout=timeout, isolation_level=isolation_level
+            )
         else:
             if autocommit == -1:
                 autocommit = sqlite3.LEGACY_TRANSACTION_CONTROL
             return sqlite3.connect(
-                database, timeout=timeout, isolation_level=isolation_level, autocommit=autocommit
+                database,
+                timeout=timeout,
+                isolation_level=isolation_level,
+                autocommit=autocommit,
             )
     raise Exception(f"Provider `{provider}` is not supported")


### PR DESCRIPTION
Implements __enter__ and __exit__ methods to enable using Connection objects as context managers. On clean exit, transactions are automatically committed. On exception, transactions are automatically rolled back. This provides sqlite3-compatible behavior and safer transaction handling.

Closes #95